### PR TITLE
Give branch information to TUID service.

### DIFF
--- a/activedata_etl/imports/coverage_util.py
+++ b/activedata_etl/imports/coverage_util.py
@@ -38,7 +38,7 @@ def tuid_batches(source_key, task_cluster_record, resources, iterator, path="fil
 
             with Timer("markup sources for {{num}} files", {"num": len(filenames)}):
                 # WHAT DO WE HAVE
-                found = resources.tuid_mapper.get_tuids(revision, filenames)
+                found = resources.tuid_mapper.get_tuids(revision, filenames, branch=task_cluster_record.repo.branch.name)
                 if found == None:
                     return  # THIS IS A FAILURE STATE, AND A WARNING HAS ALREADY BEEN RAISED, DO NOTHING
 

--- a/vendor/tuid/client.py
+++ b/vendor/tuid/client.py
@@ -49,17 +49,17 @@ class TuidClient(object):
         )
         """)
 
-    def get_tuid(self, revision, file):
+    def get_tuid(self, revision, file, branch='mozilla-central'):
         """
         :param revision: THE REVISION NUNMBER
         :param file: THE FULL PATH TO A SINGLE FILE
         :return: A LIST OF TUIDS
         """
-        service_response = wrap(self.get_tuids(revision, [file]))
+        service_response = wrap(self.get_tuids(revision, [file], branch=branch))
         for f, t in service_response.items():
             return t
 
-    def get_tuids(self, revision, files):
+    def get_tuids(self, revision, files, branch='mozilla-central'):
         """
         GET TUIDS FROM ENDPOINT, AND STORE IN DB
         :param revision:
@@ -93,6 +93,7 @@ class TuidClient(object):
                             {"eq": {"revision": revision}},
                             {"in": {"path": remaining}}
                         ]},
+                        "branch": branch,
                         "meta": {
                             "format": "list",
                             "request_time": Date.now()


### PR DESCRIPTION
This patch would give branch information to the TUID mapping requests. With this change, the service will return less error results, and also map code coverage from the 'try' branch .